### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Team training, drills, and interschool soccer matches",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Practice basketball fundamentals and compete in friendly games",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["ava@mergington.edu", "isabella@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore painting, sketching, and mixed media art projects",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["mia@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Develop acting skills and perform in school theater productions",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    },
+    "Math Olympiad": {
+        "description": "Solve advanced math problems and prepare for competitions",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["ethan@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Debate Society": {
+        "description": "Practice public speaking, argumentation, and critical thinking",
+        "schedule": "Mondays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["evelyn@mergington.edu", "abigail@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -12,6 +12,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +20,24 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsMarkup = details.participants.length
+          ? `<ul class="participants-list">${details.participants
+              .map(
+                (participant) =>
+                  `<li class="participant-item"><span>${participant}</span><button type="button" class="delete-participant-btn" data-activity="${encodeURIComponent(name)}" data-participant="${encodeURIComponent(participant)}" aria-label="Unregister ${participant}">🗑️</button></li>`
+              )
+              .join("")}</ul>`
+          : '<p class="participants-empty">No participants yet</p>';
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title"><strong>Participants</strong></p>
+            ${participantsMarkup}
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +75,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +92,50 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const deleteButton = event.target.closest(".delete-participant-btn");
+    if (!deleteButton) {
+      return;
+    }
+
+    const activity = decodeURIComponent(deleteButton.dataset.activity || "");
+    const participant = decodeURIComponent(deleteButton.dataset.participant || "");
+
+    if (!(activity && participant)) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(participant)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister participant. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,59 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid #e3e7ef;
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  color: #1a237e;
+}
+
+.participants-list {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+  color: #333;
+}
+
+.participants-list li {
+  margin-bottom: 4px;
+}
+
+.participants-list li:last-child {
+  margin-bottom: 0;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.delete-participant-btn {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.delete-participant-btn:hover {
+  opacity: 0.75;
+  background: transparent;
+}
+
+.participants-empty {
+  margin: 0;
+  font-style: italic;
+  color: #666;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import copy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_data():
+    original_activities = copy.deepcopy(activities)
+    yield
+    activities.clear()
+    activities.update(copy.deepcopy(original_activities))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,4 +16,4 @@ def reset_activities_data():
     original_activities = copy.deepcopy(activities)
     yield
     activities.clear()
-    activities.update(copy.deepcopy(original_activities))
+    activities.update(original_activities)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,142 @@
+def test_root_redirects_to_static_index(client):
+    # Arrange
+    expected_location = "/static/index.html"
+
+    # Act
+    response = client.get("/", follow_redirects=False)
+
+    # Assert
+    assert response.status_code in {302, 307}
+    assert response.headers["location"] == expected_location
+
+
+def test_get_activities_returns_activity_mapping(client):
+    # Arrange
+    expected_activity_name = "Chess Club"
+
+    # Act
+    response = client.get("/activities")
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert isinstance(payload, dict)
+    assert expected_activity_name in payload
+    assert "participants" in payload[expected_activity_name]
+
+
+def test_signup_adds_new_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "new.student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Signed up {email} for {activity_name}"}
+
+    activities_response = client.get("/activities")
+    participants = activities_response.json()[activity_name]["participants"]
+    assert email in participants
+
+
+def test_signup_returns_400_for_existing_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": existing_email},
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+def test_signup_returns_404_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Nonexistent Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_returns_422_when_email_is_missing(client):
+    # Arrange
+    activity_name = "Chess Club"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup")
+
+    # Assert
+    assert response.status_code == 422
+
+
+def test_unregister_removes_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = "michael@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/unregister",
+        params={"email": existing_email},
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Unregistered {existing_email} from {activity_name}"}
+
+    activities_response = client.get("/activities")
+    participants = activities_response.json()[activity_name]["participants"]
+    assert existing_email not in participants
+
+
+def test_unregister_returns_404_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Nonexistent Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/unregister", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_returns_404_for_non_member(client):
+    # Arrange
+    activity_name = "Chess Club"
+    non_member_email = "absent.student@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/unregister",
+        params={"email": non_member_email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Student is not signed up for this activity"
+
+
+def test_unregister_returns_422_when_email_is_missing(client):
+    # Arrange
+    activity_name = "Chess Club"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/unregister")
+
+    # Assert
+    assert response.status_code == 422


### PR DESCRIPTION
This pull request introduces several new features and improvements to the school activities management application. It adds new activities, enables unregistering participants both via the API and the frontend, improves the UI to display and manage participants, and introduces comprehensive automated tests for these features. The changes also include test infrastructure enhancements to ensure data isolation across tests.

**Backend features and API improvements:**

* Added support for unregistering a student from an activity via a new `DELETE /activities/{activity_name}/unregister` endpoint, with appropriate error handling for unknown activities and non-participants.
* Enhanced the signup endpoint to prevent duplicate signups by returning a 400 error if a student is already signed up.
* Expanded the in-memory `activities` data to include several new activities, each with their own schedule, description, and participants.

**Frontend and UI enhancements:**

* Updated the frontend to display participants for each activity, including a styled participant list and an "unregister" (delete) button for each participant. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R15-R40) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R77-R129)
* Implemented frontend logic to allow unregistering participants directly from the UI, calling the new backend endpoint and updating the display accordingly.
* Improved the UI by resetting the activity dropdown and re-fetching activities after signup or unregister actions to reflect the latest state.

**Testing and infrastructure:**

* Added a comprehensive test suite covering root redirects, activity listing, signup (including error cases), and unregistering participants (including error cases and missing parameters).
* Introduced a test fixture to reset the `activities` data between tests, ensuring test isolation and preventing side effects.